### PR TITLE
Add parameter to CreditCard model that can hold a card's swiped data

### DIFF
--- a/src/Omnipay/Common/CreditCard.php
+++ b/src/Omnipay/Common/CreditCard.php
@@ -545,6 +545,28 @@ class CreditCard
     }
 
     /**
+     * Store the raw track information from a credit card's magnetic strip
+     *
+     * @param string $value
+     *
+     * @return CreditCard
+     */
+    public function setSwipeData($value)
+    {
+        return $this->setParameter('swipeData', $value);
+    }
+
+    /**
+     * Get the raw track information stored on a credit card's magnetic strip
+     *
+     * @return string
+     */
+    public function getSwipeData()
+    {
+        return $this->getParameter('swipeData');
+    }
+
+    /**
      * Get the card issue number.
      *
      * @return string

--- a/tests/Omnipay/Common/CreditCardTest.php
+++ b/tests/Omnipay/Common/CreditCardTest.php
@@ -309,6 +309,12 @@ class CreditCardTest extends TestCase
         $this->assertEquals('456', $this->card->getCvv());
     }
 
+    public function testSwipeData()
+    {
+        $this->card->setSwipeData('%25B4242424242424242%5ETESTLAST%2FTESTFIRST%5E1505201425400714000000%3F%3B4242424242424242%3D150520142547140130%3F');
+        $this->assertSame('%25B4242424242424242%5ETESTLAST%2FTESTFIRST%5E1505201425400714000000%3F%3B4242424242424242%3D150520142547140130%3F', $this->card->getSwipeData());
+    }
+
     public function testIssueNumber()
     {
         $this->card->setIssueNumber('12');


### PR DESCRIPTION
The changes in this repo are tagged as a [release v2.4.1](https://github.com/rushi/omnipay-common/releases/tag/v2.4.1) because several other libraries reference `omnipay/common` in their composer.json depending on `~2.0`. If this change wasn't tagged then the composer.json of all other libraries (like `omnipay/omnipay` & `xola/omnipay-bundle`) would have to be updated so that omnipay/common references `dev-master` instead of ~2.0

TODO: Transfer repository over to @xola
